### PR TITLE
Fix IconicValueConverter when JSON empty

### DIFF
--- a/ValueConverters/IconicValueConverter.cs
+++ b/ValueConverters/IconicValueConverter.cs
@@ -23,6 +23,7 @@ namespace Koben.Iconic.ValueConverters
         {
             if (source == null) return string.Empty;
             var obj = JObject.Parse(source.ToString());
+            if (obj.Count == 0) return string.Empty; 
             return new HtmlString(obj["iconDisplay"].ToString());
         }
     }


### PR DESCRIPTION
If the content editor does not select an Icon, the value will be saved as `{{}}` not null.
In this instance, the JSON object does not contain `iconDisplay`, so we should return string.Empty.