### PR TITLE
#30 fixed relative path issues

### DIFF
--- a/Iconic/App_Plugins/Iconic/js/src/iconic.controller.js
+++ b/Iconic/App_Plugins/Iconic/js/src/iconic.controller.js
@@ -49,7 +49,7 @@
                 
                 $scope.pckg = loadPackage(config.packages, $scope.model.value.packageId);
                 if ($scope.pckg) {
-                    assetsService.loadCss('~/' + $scope.pckg.cssfile);
+                    assetsService.loadCss('~/' + $scope.pckg.cssfile.replace("wwwroot/", ""));
                     $scope.modelIsValid = true;
                 }
             } else {

--- a/Iconic/App_Plugins/Iconic/js/src/iconic.prevalues.editor.controller.js
+++ b/Iconic/App_Plugins/Iconic/js/src/iconic.prevalues.editor.controller.js
@@ -136,7 +136,7 @@
         if (!item.sourcefile) item.sourcefile = item.cssfile;
 
 
-        var path = umbRequestHelper.convertVirtualToAbsolutePath("~" + item.sourcefile.replace("wwwroot",""));
+        var path = umbRequestHelper.convertVirtualToAbsolutePath("~/" + item.sourcefile.replace("wwwroot",""));
 
         $http.get(path).then(
             function (response) {


### PR DESCRIPTION
prevalues controller wont work for me unless I add that slash as the file selected by angular has no / before the first folder

for the second "fix" I had to add the / behind the wwwroot replace else it ends up searching outside of the domain. Maybe a good idea to have a function somewhere that makes sure the paths are in order instead of doing .replace in multiple places.